### PR TITLE
Removed reference from $data parameter in __responseWriteCallback

### DIFF
--- a/src/SimpleEmailServiceRequest.php
+++ b/src/SimpleEmailServiceRequest.php
@@ -232,8 +232,7 @@ class SimpleEmailServiceRequest
 	* @param string $data Data
 	* @return integer
 	*/
-	private function __responseWriteCallback($curl, &$data) {
-		
+	private function __responseWriteCallback($curl, $data) {
 		if (!isset($this->response->body)) {
 			$this->response->body = $data;
 		} else {


### PR DESCRIPTION
Warning in php 8.0: Argument #2 ($data) must be passed by reference.